### PR TITLE
Update Upload Artifact action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -284,7 +284,7 @@ runs:
       id: upload-artifacts
       if: steps.export-paths.outputs.artifact_paths != ''
       continue-on-error: true
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       with:


### PR DESCRIPTION
because of: Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/