### PR TITLE
Harden GitHub Actions: pin actions to SHAs and set explicit permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -10,15 +10,18 @@ on:
       - src/*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-dist:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
 
       - name: Install Deps
         run: npm ci
@@ -36,7 +39,7 @@ jobs:
         id: diff
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/test-iac.yml
+++ b/.github/workflows/test-iac.yml
@@ -4,6 +4,9 @@ name: Test IaC Checks
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-iac-check:
     runs-on: ubuntu-latest
@@ -11,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Steampipe
-        uses: turbot/steampipe-action-setup@v1
+        uses: turbot/steampipe-action-setup@48bd85e67fddae9843fe2ad7ef6af96a332507c5 # v1
         with:
           plugin-connections: |
             connection "aws_tf" {

--- a/.github/workflows/test-non-iac.yml
+++ b/.github/workflows/test-non-iac.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   run-control:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Steampipe
-        uses: turbot/steampipe-action-setup@v1
+        uses: turbot/steampipe-action-setup@48bd85e67fddae9843fe2ad7ef6af96a332507c5 # v1
 
       - name: Install Powerpipe
         run: |
@@ -42,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Steampipe
-        uses: turbot/steampipe-action-setup@v1
+        uses: turbot/steampipe-action-setup@48bd85e67fddae9843fe2ad7ef6af96a332507c5 # v1
 
       - name: Install Powerpipe
         run: |


### PR DESCRIPTION
## Harden GitHub Actions workflows

- Pin all action/workflow references to immutable commit SHAs
- Add explicit minimal `permissions` blocks

**Why**: Prevents supply chain attacks where a tag could be moved to point to malicious code. Explicit permissions reduce blast radius if a workflow is compromised.