### PR TITLE
Pin actions to commit SHAs

### DIFF
--- a/.github/workflows/test-iac.yml
+++ b/.github/workflows/test-iac.yml
@@ -11,7 +11,7 @@ jobs:
   run-iac-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Steampipe
         uses: turbot/steampipe-action-setup@48bd85e67fddae9843fe2ad7ef6af96a332507c5 # v1

--- a/.github/workflows/test-non-iac.yml
+++ b/.github/workflows/test-non-iac.yml
@@ -13,7 +13,7 @@ jobs:
   run-control:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Steampipe
         uses: turbot/steampipe-action-setup@48bd85e67fddae9843fe2ad7ef6af96a332507c5 # v1
@@ -42,7 +42,7 @@ jobs:
   run-benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Steampipe
         uses: turbot/steampipe-action-setup@48bd85e67fddae9843fe2ad7ef6af96a332507c5 # v1
@@ -71,7 +71,7 @@ jobs:
   test-database-flag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Powerpipe
         run: |


### PR DESCRIPTION
## Summary
- Pin remaining unpinned action references to immutable commit SHAs for supply-chain security.

### Actions pinned
- `actions/checkout@v4` -> `34e114876b0b11c390a56381ad16ebd13914f8d5`